### PR TITLE
Adds flattened data type

### DIFF
--- a/generator/gostruct/gostruct.go
+++ b/generator/gostruct/gostruct.go
@@ -175,6 +175,9 @@ func GoFieldType(n *ecsgen.Node) string {
 	case "object":
 		typeBuf.WriteString("map[string]interface{}")
 		return typeBuf.String()
+	case "flattened":
+		typeBuf.WriteString("map[string]string")
+		return typeBuf.String()
 	default:
 		panic(fmt.Errorf("no translation for %v (field %s)", n.Definition.Type, n.Name))
 	}


### PR DESCRIPTION
Adds the field type definition for [flattened](https://www.elastic.co/guide/en/elasticsearch/reference/master/flattened.html).

## Testing
- Set winlog.event_id to `flattened` type
- Generated the master ECS flattened YAML file using `github.com/elastic/ecs`

```
winlog.event_id:
  dashed_name: winlog-event-id
  description: The event identifier. The value is specific to the source of the event.
  flat_name: winlog.event_id
  level: custom
  name: event_id
  normalize: []
  short: The event identifier. The value is specific to the source of the event.
  type: flattened
```

- ran ecsgen and can see it has generated Winlog.EventId as a `map[string]string`

<img width="913" alt="Screen Shot 2020-12-22 at 10 57 19 AM" src="https://user-images.githubusercontent.com/10608855/102937892-010b5080-4460-11eb-87db-fd8eb893454a.png">
