### PR TITLE
Add missing/new field types

### DIFF
--- a/generator/gostruct/gostruct.go
+++ b/generator/gostruct/gostruct.go
@@ -154,7 +154,7 @@ func GoFieldType(n *ecsgen.Node) string {
 
 	// Find the right type!
 	switch n.Definition.Type {
-	case "keyword", "text", "ip", "geo_point", "constant_keyword":
+	case "keyword", "text", "ip", "geo_point", "constant_keyword", "match_only_text", "wildcard":
 		typeBuf.WriteString("string")
 		return typeBuf.String()
 	case "long":


### PR DESCRIPTION
### Summary
When attempting to generate `ecs_flat.yaml` from latest https://github.com/elastic/ecs, I got the following errors:

```
rachel.takeuchi@rachel-takeuchi-C02Z534HLVDQ ecsgen % ecsgen generate --source-file ~/src/ecs/generated/ecs/ecs_flat.yml --output-plugin="gostruct" --opt-gostruct-package-name="ecs" --opt-gostruct-output-dir="/Users/rachel.takeuchi/src" --opt-gostruct-marshal-json
[ECS:gen]  INFO Running Generator
panic: no translation for wildcard (field stack_trace)

goroutine 1 [running]:
github.com/gen0cide/ecsgen/generator/gostruct.GoFieldType(0xc0002cf200, 0xb, 0xc0003e57b6)
	/Users/rachel.takeuchi/gocode/src/github.com/gen0cide/ecsgen/generator/gostruct/gostruct.go:182 +0xed0
github.com/gen0cide/ecsgen/generator/gostruct.(*basic).ToGoCode(0xc000094d80, 0xc00023e340, 0x5, 0xc00023e340, 0x0, 0x0)
	/Users/rachel.takeuchi/gocode/src/github.com/gen0cide/ecsgen/generator/gostruct/gostruct.go:221 +0x695
github.com/gen0cide/ecsgen/generator/gostruct.(*basic).Execute(0xc000094d80, 0xc0000d0850, 0x1, 0x1)
	/Users/rachel.takeuchi/gocode/src/github.com/gen0cide/ecsgen/generator/gostruct/gostruct.go:483 +0x486
main.generate(0xc000222280, 0xa, 0x12)
	/Users/rachel.takeuchi/gocode/src/github.com/gen0cide/ecsgen/cmd/ecsgen/generate.go:56 +0x160
github.com/urfave/cli/v2.(*Command).Run(0xc0000f17a0, 0xc0002220c0, 0x0, 0x0)
	/Users/rachel.takeuchi/gocode/pkg/mod/github.com/urfave/cli/v2@v2.3.0/command.go:163 +0x4b9
github.com/urfave/cli/v2.(*App).RunContext(0xc00020a000, 0x1687b00, 0xc0000c4008, 0xc0000ce000, 0x8, 0x8, 0x0, 0x0)
	/Users/rachel.takeuchi/gocode/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:313 +0x790
github.com/urfave/cli/v2.(*App).Run(...)
	/Users/rachel.takeuchi/gocode/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:224
main.main()
	/Users/rachel.takeuchi/gocode/src/github.com/gen0cide/ecsgen/cmd/ecsgen/main.go:55 +0x409
```

```
rachel.takeuchi@rachel-takeuchi-C02Z534HLVDQ src % ecsgen generate --source-file ecs/generated/ecs/ecs_flat.yml --output-plugin="gostruct" --opt-gostruct-package-name="ecs" --opt-gostruct-output-dir="." --opt-gostruct-marshal-json 
[ECS:gen]  INFO Running Generator
panic: no translation for match_only_text (field message)

goroutine 1 [running]:
github.com/gen0cide/ecsgen/generator/gostruct.GoFieldType(0xc0008751c0, 0x7, 0xc000b9f8b7)
	/Users/rachel.takeuchi/gocode/src/github.com/gen0cide/ecsgen/generator/gostruct/gostruct.go:182 +0xd8e
github.com/gen0cide/ecsgen/generator/gostruct.(*basic).CreateBase(0xc00007cdc0, 0xc000151480, 0xd, 0xd, 0x0, 0x0)
	/Users/rachel.takeuchi/gocode/src/github.com/gen0cide/ecsgen/generator/gostruct/gostruct.go:334 +0x718
github.com/gen0cide/ecsgen/generator/gostruct.(*basic).Execute(0xc00007cdc0, 0xc000151480, 0x1, 0x1)
	/Users/rachel.takeuchi/gocode/src/github.com/gen0cide/ecsgen/generator/gostruct/gostruct.go:471 +0x31c
main.generate(0xc0001e8280, 0xa, 0x12)
	/Users/rachel.takeuchi/gocode/src/github.com/gen0cide/ecsgen/cmd/ecsgen/generate.go:56 +0x160
github.com/urfave/cli/v2.(*Command).Run(0xc0000db9e0, 0xc0001e80c0, 0x0, 0x0)
	/Users/rachel.takeuchi/gocode/pkg/mod/github.com/urfave/cli/v2@v2.3.0/command.go:163 +0x4b9
github.com/urfave/cli/v2.(*App).RunContext(0xc00017e820, 0x16879c0, 0xc000028088, 0xc000020080, 0x8, 0x8, 0x0, 0x0)
	/Users/rachel.takeuchi/gocode/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:313 +0x790
github.com/urfave/cli/v2.(*App).Run(...)
	/Users/rachel.takeuchi/gocode/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:224
main.main()
	/Users/rachel.takeuchi/gocode/src/github.com/gen0cide/ecsgen/cmd/ecsgen/main.go:55 +0x409
```

### Fixes

- adds `wildcard` and `match_only_text` to gostruct.go as strings

### Testing

- applied changes manually, re-installed ecsgen and successfully generated ecs_flat.yaml
```
rachel.takeuchi@rachel-takeuchi-C02Z534HLVDQ ecsgen % ecsgen generate --source-file ~/src/ecs/generated/ecs/ecs_flat.yml --output-plugin="gostruct" --opt-gostruct-package-name="ecs" --opt-gostruct-output-dir="/Users/rachel.takeuchi/src" --opt-gostruct-marshal-json
[ECS:gen]  INFO Running Generator
[ECS:gen]  INFO Successfully executed gostruct generator
```