### PR TITLE
Add weak unmarshal flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Gostruct is used to generate Go code for an ECS object. It has a few options:
 --opt-gostruct-output-dir value       Path to the directory where the generated code should be written. [$ECSGEN_OPT_GOSTRUCT_OUTPUT_DIR]
 --opt-gostruct-output-filename value  Destination filename for the generated code. (default: generated_ecs.go) [$ECSGEN_OPT_GOSTRUCT_OUTPUT_FILENAME]
 --opt-gostruct-marshal-json           Include a json.Marshaler implementation that removes empty fields. (default: false) [$ECSGEN_OPT_GOSTRUCT_MARSHAL_JSON]
---opt-gostruct-remove-at              Remove @ character from @timestamp field. (default: false) [$ECSGEN_OPT_GOSTRUCT_REMOVE_AT]
+--opt-gostruct-weak-unmarshal         If set, when unmarshalling objects it will convert scalar types to arrays, non numeric types to numeric and vice versa. (default: false) [$ECSGEN_OPT_GOSTRUCT_WEAK_UNMARSHAL]
 ```
 
 The `--opt-gostruct-marshal-json` is shown in the examples/go/with-json-marshaling example directory.


### PR DESCRIPTION
- This PR adds a new weak unmarshal flag, it allows the user to generate and override the UnmarshalJSON function that will be able to unmarshal other types of values on []string, int32 and int64 fields. i.e. it will put scalar string into an array, convert a string to integer, convert a float to integer when unmarshalling. It uses the GJSON open source library

- After running some benchmark tests, this does impact performance a by 40% so will look into tuning this in the future
- Also, remove the 'remote-at' flag since it is not needed anymore